### PR TITLE
make prompts a little more explicit

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -47,18 +47,18 @@ function createAuth (options, callback) {
 
 
 function prompt (callback) {
-  read({ prompt: 'GitHub username:' }, function (err, user) {
+  read({ prompt: 'Your GitHub username:' }, function (err, user) {
     if (err)
       return callback(err)
 
     if (user === '')
       return callback()
 
-    read({ prompt: 'GitHub password:', silent: true, replace: '\u2714' }, function (err, pass) {
+    read({ prompt: 'Your GitHub password:', silent: true, replace: '\u2714' }, function (err, pass) {
       if (err)
         return callback(err)
 
-      read({ prompt: 'GitHub OTP (optional):' }, function (err, otp) {
+      read({ prompt: 'Your GitHub OTP/2FA Code (optional):' }, function (err, otp) {
         if (err)
           return callback(err)
 


### PR DESCRIPTION
i'm using ghauth in https://www.npmjs.org/package/collaborator and it's a little confusing because you do

```
$ cd myrepo
$ collaborator rvagg
$ GitHub Username: maxogden
$ GitHub Password: *********
```

this changes it to: 

```
$ cd myrepo
$ collaborator rvagg
$ Your GitHub Username: maxogden
$ Your GitHub Password: *********
```

which helps clarify that they should enter e.g. `maxogden` instead of `rvagg`
