### PR TITLE
pass back entire response from github in case of error

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -32,7 +32,7 @@ function createAuth (options, callback) {
     data = JSON.parse(data.toString())
 
     if (data.message)
-      return callback(new Error(data))
+      return callback(new Error(JSON.stringify(data)))
     if (!data.token)
       return callback(new Error('No token from GitHub!'))
 


### PR DESCRIPTION
current behavior conceals valuable information, e.g. 

```
$ node test.js 
Your GitHub username: maxogden
Your GitHub password: ✔✔✔

Your GitHub OTP/2FA Code (optional): 999999
[Error: Validation Failed]
```

this PR changes it to this:

```
$ node test.js 
Your GitHub username: maxogden
Your GitHub password: ✔✔✔

Your GitHub OTP/2FA Code (optional): 999999
[Error: {"message":"Validation Failed","documentation_url":"https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization","errors":[{"resource":"OauthAccess","code":"already_exists","field":"description"}]}]
```

in this case the problem was that I guess github has a unique constraint on the app `description` field and it wants me to change it?
