### PR TITLE
Add option for prompting for token note

### DIFF
--- a/example.js
+++ b/example.js
@@ -11,6 +11,9 @@ const ghauth = require('./')
 
           // (optional)
         , userAgent  : 'My Awesome App'
+
+          // (optional) prompt for the token note field
+        , promptNote : true
       }
 
 ghauth(authOptions, function (err, authData) {


### PR DESCRIPTION
In the case where the user might have to refresh their token, it's up to the ghauth library consumer to implement their own prompting for the token note (which must be unique). This adds an option (default: falsey) to prompt the user to name their token before entering credentials.

I didn't want to bring in any dependencies (specifically for async control-flow), so I implemented a somewhat hacky solution for that conditional async action.

Anyhow, if you're interested, here it is!
