### PR TITLE
ensure note is always unique to allow logins on multiple machines

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -22,6 +22,8 @@ function createAuth (options, callback) {
     , method  : 'post'
     , auth    : options.user + ':' + options.pass
   }
+  
+  var currentDate = new Date().toJSON()
 
   var req = hyperquest(authUrl, reqOptions)
 
@@ -41,7 +43,7 @@ function createAuth (options, callback) {
 
   req.end(JSON.stringify({
       scopes : options.scopes || defaultScopes
-    , note   : options.note   || defaultNote
+    , note   : (options.note   || defaultNote) + ' (' + currentDate + ')'
   }))
 }
 
@@ -69,7 +71,7 @@ function prompt (options, callback) {
         var req = hyperquest(authUrl, reqOptions, function (err, response) {
           if (err)
             return callback(err)
-            
+
           var otp = response.headers['x-github-otp']
           if (!otp || otp.indexOf('required') < 0)
             return callback(null, { user: user, pass: pass, otp: null })


### PR DESCRIPTION
This appends the current date to prevent validation failures due to a token already existing for a given name (try authing the same command on two computers, or nuking your local config without nuking the token in github to see what I mean).

`````` js
{"message":"Validation Failed","documentation_url":"https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization","errors":[{"resource":"OauthAccess","code":"already_exists","field":"description"}]}```
``````
