### PR TITLE
Adds noSave option for non-persistent auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ $ node awesome.js
   token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
 ```
 
+Optionally persistency can be turned off by setting the option `'noSave'` to `true`.
+However only use this if you are sure about it, since repeating GitHub authentications
+will be rejected by the API.
+
 ## License
 
 **ghauth** is Copyright (c) 2014 Rod Vagg [@rvagg](https://github.com/rvagg) and licensed under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE file for more details.

--- a/ghauth.js
+++ b/ghauth.js
@@ -90,15 +90,19 @@ function auth (options, callback) {
   var configPath = path.join(process.env.HOME || process.env.USERPROFILE, '.config', options.configName + '.json')
     , authData
 
-  mkdirp.sync(path.dirname(configPath))
+  if (!options.noSave) {
 
-  try {
-    authData = require(configPath)
-  } catch (e) {}
+    mkdirp.sync(path.dirname(configPath))
 
-  if (authData && authData.user && authData.token)
-    return callback(null, authData)
+    try {
+      authData = require(configPath)
+    } catch (e) {}
 
+    if (authData && authData.user && authData.token)
+      return callback(null, authData)
+
+  }
+  
   prompt(options, function (err, data) {
     if (err)
       return callback(err)
@@ -109,6 +113,9 @@ function auth (options, callback) {
 
       var tokenData = { user: data.user, token: token }
 
+      if (options.noSave) 
+        return callback(null, tokenData)
+      
       fs.writeFile(configPath, JSON.stringify(tokenData), 'utf8', function (err) {
         if (err)
           return callback(err)


### PR DESCRIPTION
Hey,

I only need a temporary github token, which I use to get a travis token. I now added an option called `noSave` to allow usage of the module without saving.

Alternatively I guess it would also be possible to take the prompting and authing to another module, which [I also tried](https://github.com/finnp/ghauth/blob/master/index.js). But maybe this is a simpler solution?

Best,
Finn
