### PR TITLE
Add authUrl and promptName options.

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -50,14 +50,18 @@ function createAuth (options, callback) {
 
 
 function prompt (options, callback) {
-  read({ prompt: 'Your GitHub username:' }, function (err, user) {
+  var promptName     = options.promptName || 'GitHub'
+    , usernamePrompt = 'Your ' + promptName + ' username:'
+    , passwordPrompt = 'Your ' + promptName + ' password:'
+
+  read({ prompt: usernamePrompt }, function (err, user) {
     if (err)
       return callback(err)
 
     if (user === '')
       return callback()
 
-    read({ prompt: 'Your GitHub password:', silent: true, replace: '\u2714' }, function (err, pass) {
+    read({ prompt: passwordPrompt, silent: true, replace: '\u2714' }, function (err, pass) {
       if (err)
         return callback(err)
 


### PR DESCRIPTION
This is to support enterprise githubs. [Enterprise github api endpoints](https://developer.github.com/v3/enterprise/#endpoint-urls) aren't a domain so it needs more than specify a different domain. So I've opted to add two options one to specifically define the authorization end point and another to specify the name used to prompt for username and password so there is more clarity about what you are authorizing against.
