### PR TITLE
Pass error instead of JSON data.

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -35,10 +35,11 @@ function createAuth (options, callback) {
 
     data = JSON.parse(data.toString())
 
-    if (data.message)
+    if (data.message) {
       var error = new Error(data.message)
       error.data = data
       return callback(error)
+    }
     if (!data.token)
       return callback(new Error('No token from GitHub!'))
 

--- a/ghauth.js
+++ b/ghauth.js
@@ -36,7 +36,9 @@ function createAuth (options, callback) {
     data = JSON.parse(data.toString())
 
     if (data.message)
-      return callback(new Error(JSON.stringify(data)))
+      var error = new Error(data.message)
+      error.data = data
+      return callback(error)
     if (!data.token)
       return callback(new Error('No token from GitHub!'))
 


### PR DESCRIPTION
The point of this PR is to eliminate the additional overhead needed to parse error messages returned by the Github API. Now, the once-JSON string is a legitimate error (returned directly from Github) and the data from the original JSON object is attached to the error by using its `data` property.