### PR TITLE
set restrictive umask

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -159,6 +159,7 @@ function auth (options, callback) {
       if (options.noSave)
         return callback(null, tokenData)
 
+      process.umask(0o077);
       config.write(tokenData, afterWrite)
 
       function afterWrite (err) {


### PR DESCRIPTION
This helps prevent the user from writing the token to a world-readable file.