### PR TITLE
Implement oauth device flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ $ node awesome.js
   token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
 ```
 
+When `authUrl` is configured for a Github enterprise endpoint, it will look more like this:
+
+```console
+$ node awesome.js
+
+GitHub username: rvagg
+GitHub password: ✔✔✔✔✔✔✔✔✔✔✔✔
+GitHub OTP (optional): 669684
+
+{ user: 'rvagg',
+  token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
+```
+
 ## API
 
 <b><code>ghauth(options, callback)</code></b>
@@ -75,12 +88,13 @@ The <b><code>options</code></b> argument can have the following properties:
 * `clientId` (String, required unless `noDeviceFlow` is `true`): the clientId of your oAuth application on Github.  See [setup](#setup) below for more info on creating a Github oAuth application.
 * `configName` (String, required unless `noSave` is `true`): the name of the config you are creating, this is required for saving a `<configName>.json` file into the users config directory with the token created. Note that the **config directory is determined by [application-config](https://github.com/LinusU/node-application-config) and is OS-specific.**
 * `noSave` (Boolean, optional): if you don't want to persist the token to disk, set this to `true` but be aware that you will still be creating a saved token on GitHub that will need cleaning up if you are not persisting the token.
-* `githubHost` (String, optional):  defaults to `github.com` for public GitHub but can be configured for private GitHub Enterprise endpoints.
-* `promptName` (String, optional): defaults to `'GitHub'`, change this if you are prompting for GHE credentials.
+* `authUrl` (String, optional):  defaults to `null` since public Github no longer supports basic auth.  Setting `authUrl` will allow you to perform basic authentication with a Github Enterprise instance.  This setting is ignored if the `host` of the url is `api.github.com` or `github.com`.
+* `promptName` (String, optional): defaults to `'GitHub Enterprise'`, change this if you are prompting for GHE credentials.  Not used for public GH authentication.
 * `scopes` (Array, optional): defaults to `[]`, consult the GitHub [scopes](https://developer.github.com/v3/oauth/#scopes) documentation to see what you may need for your application.
+* `note` (String, optional):  defaults to `'Node.js command-line app with ghauth'`, override if you want to save a custom note with the GitHub token (user-visible).  Only used with GHE basic authentication.
 * `userAgent` (String, optional): defaults to `'Magic Node.js application that does magic things with ghauth'`, only used for requests to GitHub, override if you have a good reason to do so.
 * `passwordReplaceChar` (String, optional): defaults to `'✔'`, the character echoed when the user inputs their password. Can be set to `''` to silence the output.
-* `noDeviceFlow` (Boolean, optional): disable the Device Flow authentication method.  This will prompt users for a personal access token immediately if no existing configuration is found.
+* `noDeviceFlow` (Boolean, optional): disable the Device Flow authentication method.  This will prompt users for a personal access token immediately if no existing configuration is found.  Only applies when `authUrl` is not used.
 
 The <b><code>callback</code></b> will be called with either an `Error` object describing what went wrong, or a `data` object as the second argument if the auth creation (or cache read) was successful. The shape of the second argument is `{ user:String, token:String }`.
 
@@ -100,8 +114,8 @@ Github requires a `clientId` from a Github oAuth Application in order to complet
 ### v4 to v5 Upgrade guide
 
 - A `options.clientId` is required to use device flow.  Set up an oAuth application to get a `clientId`.
-- the `options.authUrl` (default: `https://api.github.com/authorizations`) is removed in favor of `options.githubHost` (default `github.com`).
-- `options.note` is no longer used for anything.
+- the `options.authUrl` now only applies to GitHub enterprise authentication which still only supports basic auth.
+- `options.note` is only used for GHE basic auth.
 - `options.noDeviceFlow` is available to skip the device flow if you are unable to create a `clientId` for some reason, and wish to skip to the personal access token input prompt immediately.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Important**
 
-Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][deprecated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup](#setup) for a simple upgrade guide between v4 and v5.
+Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).  `ghauth` v5.0.0+ supports the new [device auth flow](https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow) but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup](#setup) for a simple upgrade guide between v4 and v5.
 
 ## Example usage
 
@@ -110,7 +110,7 @@ Github requires a `clientId` from a Github oAuth Application in order to complet
 4. Select Beta Features in the settings side bar.
 4. Enable Device authorization flow.
 
-- [Device flow docs][df]
+- [Device flow docs](https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow)
 
 ### v4 to v5 Upgrade guide
 
@@ -148,6 +148,3 @@ License &amp; copyright
 Copyright (c) 2014 ghauth contributors (listed above).
 
 ghauth is licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
-
-[df]: https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
-[deprecated]: https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Important**
 
-Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][depreciated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup][#setup] for a simple upgrade guide between v4 and v5.
+Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][deprecated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup][#setup] for a simple upgrade guide between v4 and v5.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Important**
 
-Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][deprecated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup][#setup] for a simple upgrade guide between v4 and v5.
+Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][deprecated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup](#setup) for a simple upgrade guide between v4 and v5.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ Github requires a `clientId` from a Github oAuth Application in order to complet
   - [Personal Account oAuth apps page](https://github.com/settings/developers)
   - `https://github.com/organizations/${org_name}/settings/applications`: Organization oAuth settings page.
 2. Provide an application name, homepage URL and callback URL.  You can make these two URLs the same, since your app will not be using a callback URL with the device flow.
-3. Go to your oAuth application's settings page and select Beta Features.
+3. Go to your oAuth application's settings page and take note of the "Client ID" (this will get passed as `clientId` to `ghauth`).  You can ignore the "Client Secret" value.  It is not used.
+4. Select Beta Features in the settings side bar.
 4. Enable Device authorization flow.
 
 - [Device flow docs][df]

--- a/README.md
+++ b/README.md
@@ -4,19 +4,23 @@
 
 [![NPM](https://nodei.co/npm/ghauth.svg)](https://nodei.co/npm/ghauth/)
 
+**Important**
+
+Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020][depreciated].  `ghauth` v5.0.0+ supports the new [device auth flow][df] but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup][#setup] for a simple upgrade guide between v4 and v5.
+
 ## Example usage
 
 ```js
 const ghauth = require('ghauth')
 const authOptions = {
+  // provide a clientId from a Github oAuth application registration
+  clientId: '123456',
+
   // awesome.json within the user's config directory will store the token
   configName: 'awesome',
 
   // (optional) whatever GitHub auth scopes you require
   scopes: [ 'user' ],
-
-  // (optional) saved with the token on GitHub
-  note: 'This token is for my awesome app',
 
   // (optional)
   userAgent: 'My Awesome App'
@@ -35,20 +39,27 @@ console.log(authData)
 
 Will run something like this:
 
-```
+```console
 $ node awesome.js
+  Authorize with GitHub by opening this URL in a browser:
 
-GitHub username: rvagg
-GitHub password: ✔✔✔✔✔✔✔✔✔✔✔✔
-GitHub OTP (optional): 669684
+    https://github.com/login/device
 
-{ user: 'rvagg',
-  token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
+  and enter the following User Code:
+  (or press ⏎ to enter a personal access token)
+
+✔ Device flow complete.  Manage at https://github.com/settings/connections/applications/123456
+✔ Authorized for rvagg
+Wrote access token to "~/.config/awesome/config.json"
+{
+  token: '24d5dee258c64aef38a66c0c5eca459c379901c2',
+  user: 'rvagg'
+}
 ```
 
 Because the token is persisted, the next time you run it there will be no prompts:
 
-```
+```console
 $ node awesome.js
 
 { user: 'rvagg',
@@ -61,16 +72,37 @@ $ node awesome.js
 
 The <b><code>options</code></b> argument can have the following properties:
 
+* `clientId` (String, required unless `noDeviceFlow` is `true`): the clientId of your oAuth application on Github.  See [setup](#setup) below for more info on creating a Github oAuth application.
 * `configName` (String, required unless `noSave` is `true`): the name of the config you are creating, this is required for saving a `<configName>.json` file into the users config directory with the token created. Note that the **config directory is determined by [application-config](https://github.com/LinusU/node-application-config) and is OS-specific.**
 * `noSave` (Boolean, optional): if you don't want to persist the token to disk, set this to `true` but be aware that you will still be creating a saved token on GitHub that will need cleaning up if you are not persisting the token.
-* `authUrl` (String, optional):  defaults to `https://api.github.com/authorizations` for public GitHub but can be configured for private GitHub Enterprise endpoints.
+* `githubHost` (String, optional):  defaults to `github.com` for public GitHub but can be configured for private GitHub Enterprise endpoints.
 * `promptName` (String, optional): defaults to `'GitHub'`, change this if you are prompting for GHE credentials.
 * `scopes` (Array, optional): defaults to `[]`, consult the GitHub [scopes](https://developer.github.com/v3/oauth/#scopes) documentation to see what you may need for your application.
-* `note` (String, optional):  defaults to `'Node.js command-line app with ghauth'`, override if you want to save a custom note with the GitHub token (user-visible).
 * `userAgent` (String, optional): defaults to `'Magic Node.js application that does magic things with ghauth'`, only used for requests to GitHub, override if you have a good reason to do so.
 * `passwordReplaceChar` (String, optional): defaults to `'✔'`, the character echoed when the user inputs their password. Can be set to `''` to silence the output.
+* `noDeviceFlow` (Boolean, optional): disable the Device Flow authentication method.  This will prompt users for a personal access token immediately if no existing configuration is found.
 
 The <b><code>callback</code></b> will be called with either an `Error` object describing what went wrong, or a `data` object as the second argument if the auth creation (or cache read) was successful. The shape of the second argument is `{ user:String, token:String }`.
+
+## Setup
+
+Github requires a `clientId` from a Github oAuth Application in order to complete oAuth device flow authentication.
+
+1. Register an "oAuth App" with Github:
+  - [Personal Account oAuth apps page](https://github.com/settings/developers)
+  - `https://github.com/organizations/${org_name}/settings/applications`: Organization oAuth settings page.
+2. Provide an application name, homepage URL and callback URL.  You can make these two URLs the same, since your app will not be using a callback URL with the device flow.
+3. Go to your oAuth application's settings page and select Beta Features.
+4. Enable Device authorization flow.
+
+- [Device flow docs][df]
+
+### v4 to v5 Upgrade guide
+
+- A `options.clientId` is required to use device flow.  Set up an oAuth application to get a `clientId`.
+- the `options.authUrl` (default: `https://api.github.com/authorizations`) is removed in favor of `options.githubHost` (default `github.com`).
+- `options.note` is no longer used for anything.
+- `options.noDeviceFlow` is available to skip the device flow if you are unable to create a `clientId` for some reason, and wish to skip to the personal access token input prompt immediately.
 
 ## Contributing
 
@@ -92,6 +124,7 @@ ghauth is made possible by the excellent work of the following contributors:
 <tr><th align="left">Rod Vagg</th><td><a href="https://github.com/rvagg">GitHub/rvagg</a></td><td><a href="http://twitter.com/rvagg">Twitter/@rvagg</a></td></tr>
 <tr><th align="left">Jeppe Nejsum Madsen</th><td><a href="https://github.com/jeppenejsum">GitHub/jeppenejsum</a></td><td><a href="http://twitter.com/nejsum">Twitter/@nejsum</a></td></tr>
 <tr><th align="left">Max Ogden</th><td><a href="https://github.com/maxogden">GitHub/maxogden</a></td><td><a href="http://twitter.com/maxogden">Twitter/@maxogden</a></td></tr>
+<tr><th align="left">Bret Comnes</th><td><a href="https://github.com/bcomnes">GitHub/bcomnes</a></td><td><a href="http://twitter.com/bcomnes">Twitter/@bcomnes</a></td></tr>
 </tbody></table>
 
 License &amp; copyright
@@ -100,3 +133,6 @@ License &amp; copyright
 Copyright (c) 2014 ghauth contributors (listed above).
 
 ghauth is licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
+
+[df]: https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
+[depreciated]: https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/

--- a/README.md
+++ b/README.md
@@ -135,4 +135,4 @@ Copyright (c) 2014 ghauth contributors (listed above).
 ghauth is licensed under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
 
 [df]: https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow
-[depreciated]: https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/
+[deprecated]: https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ The <b><code>callback</code></b> will be called with either an `Error` object de
 
 Github requires a `clientId` from a Github oAuth Application in order to complete oAuth device flow authentication.
 
-1. Register an "oAuth App" with Github:
+1. Register an "oAuth Application" with Github:
   - [Personal Account oAuth apps page](https://github.com/settings/developers)
   - `https://github.com/organizations/${org_name}/settings/applications`: Organization oAuth settings page.
 2. Provide an application name, homepage URL and callback URL.  You can make these two URLs the same, since your app will not be using a callback URL with the device flow.
@@ -114,8 +114,8 @@ Github requires a `clientId` from a Github oAuth Application in order to complet
 ### v4 to v5 Upgrade guide
 
 - A `options.clientId` is required to use device flow.  Set up an oAuth application to get a `clientId`.
-- the `options.authUrl` now only applies to GitHub enterprise authentication which still only supports basic auth.
-- `options.note` is only used for GHE basic auth.
+- the `options.authUrl` now only applies to GitHub enterprise authentication which still only supports basic auth.  Only pass this if you intend for GitHub Enterpise authentication.
+- `options.note` is only used for GHE basic auth now.  Your oAuth application details serve the purpose of token note.
 - `options.noDeviceFlow` is available to skip the device flow if you are unable to create a `clientId` for some reason, and wish to skip to the personal access token input prompt immediately.
 
 ## Contributing

--- a/example.js
+++ b/example.js
@@ -1,13 +1,13 @@
 const ghauth = require('./')
 const authOptions = {
+  // provide a clientId from a Github oAuth application registration
+  clientId: '123456',
+
   // ~/.config/awesome.json will store the token
   configName: 'awesome',
 
   // (optional) whatever GitHub auth scopes you require
   scopes: ['user'],
-
-  // (optional) saved with the token on GitHub
-  note: 'This token is for my awesome app',
 
   // (optional)
   userAgent: 'My Awesome App'

--- a/ghauth.js
+++ b/ghauth.js
@@ -12,7 +12,7 @@ const defaultScopes = []
 const defaultDeviceCodeUrl = 'https://github.com/login/device/code'
 const defaultDeviceAuthUrl = 'https://github.com/login/device'
 const defaultAccessTokenUrl = 'https://github.com/login/oauth/access_token'
-const defaultOauthAppsBaseUrl = 'https://github.com/settings/connections/applications/'
+const defaultOauthAppsBaseUrl = 'https://github.com/settings/connections/applications'
 const defaultUserEndpoint = 'https://api.github.com/user'
 const defaultPatUrl = 'https://github.com/settings/tokens'
 const defaultPromptName = 'GitHub'
@@ -49,6 +49,7 @@ async function prompt (options) {
   const promptName = options.promptName || defaultPromptName
   const deviceCodeUrl = options.deviceCodeUrl || defaultDeviceCodeUrl
   const accessTokenUrl = options.accessTokenUrl || defaultAccessTokenUrl
+  const oauthAppsBaseUrl = options.oauthAppsBaseUrl || defaultOauthAppsBaseUrl
   const scopes = options.scopes || defaultScopes
   const passwordReplaceChar = options.passwordReplaceChar || defaultPasswordReplaceChar
   const deviceFlowSpinner = ora()
@@ -129,7 +130,7 @@ async function prompt (options) {
     if (accessToken === false) return false // interrupted, don't return anything
 
     const tokenData = { token: accessToken.access_token, scope: accessToken.scope }
-    deviceFlowSpinner.succeed('Device flow complete.')
+    deviceFlowSpinner.succeed(`Device flow complete.  Manage at ${oauthAppsBaseUrl}/${options.clientId}`)
 
     return supplementUserData(tokenData)
 

--- a/ghauth.js
+++ b/ghauth.js
@@ -167,7 +167,7 @@ async function auth (options) {
     }
 
     config = appCfg(options.configName)
-    const authData = await promisify(config.read.bind(config))()
+    const authData = await config.read()
     if (authData && authData.user && authData.token) {
       // we had it saved in a config file
       return authData
@@ -190,7 +190,7 @@ async function auth (options) {
   }
 
   process.umask(0o077)
-  await promisify(config.write.bind(config))(tokenData)
+  await config.write(tokenData)
 
   process.stdout.write(`Wrote access token to "${config.filePath}"\n`)
 

--- a/ghauth.js
+++ b/ghauth.js
@@ -146,7 +146,21 @@ async function prompt (options) {
       const deviceCode = await requestDeviceCode()
 
       if (deviceCode.error) {
-        const error = new Error(deviceCode.error_description)
+        let error
+        switch (deviceCode.error) {
+          case 'Not Found': {
+            error = new Error('Not found: is the clientId correct?')
+            break
+          }
+          case 'unauthorized_client': {
+            error = new Error(`${deviceCode.error_description} Did you enable 'Device authorization flow' for your oAuth application?`)
+            break
+          }
+          default: {
+            error = new Error(deviceCode.error_description || deviceCode.error)
+            break
+          }
+        }
         error.data = deviceCode
         throw error
       }

--- a/ghauth.js
+++ b/ghauth.js
@@ -45,11 +45,12 @@ async function prompt (options) {
   const scopes = options.scopes || defaultScopes
   const passwordReplaceChar = options.passwordReplaceChar || defaultPasswordReplaceChar
   const githubHost = options.githubHost || defaultGithubHost
+  const isEnterprise = githubHost !== defaultGithubHost
   const deviceCodeUrl = `https://${githubHost}/login/device/code`
   const fallbackDeviceAuthUrl = `https://${githubHost}/login/device`
   const accessTokenUrl = `https://${githubHost}/login/oauth/access_token`
   const oauthAppsBaseUrl = `https://${githubHost}/settings/connections/applications`
-  const userEndpointUrl = `https://api.${githubHost}/user`
+  const userEndpointUrl = isEnterprise ? `https://api.${githubHost}/user` : `https://${githubHost}/api/v3`
   const patUrl = `https://${githubHost}/settings/tokens`
 
   const defaultReqOptions = {

--- a/ghauth.js
+++ b/ghauth.js
@@ -50,7 +50,8 @@ async function prompt (options) {
   const fallbackDeviceAuthUrl = `https://${githubHost}/login/device`
   const accessTokenUrl = `https://${githubHost}/login/oauth/access_token`
   const oauthAppsBaseUrl = `https://${githubHost}/settings/connections/applications`
-  const userEndpointUrl = isEnterprise ? `https://api.${githubHost}/user` : `https://${githubHost}/api/v3`
+  const apiUrl = isEnterprise ? `https://api.${githubHost}` : `https://${githubHost}/api/v3`
+  const userEndpointUrl = `${apiUrl}/user`
   const patUrl = `https://${githubHost}/settings/tokens`
 
   const defaultReqOptions = {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "application-config": "^1.0.1",
+    "application-config": "^2.0.0",
     "bl": "^4.0.0",
     "hyperquest": "^2.1.3",
     "read": "^1.0.7"

--- a/package.json
+++ b/package.json
@@ -24,11 +24,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@octokit/rest": "^18.0.3",
     "application-config": "^2.0.0",
-    "bl": "^4.0.0",
-    "hyperquest": "^2.1.3",
-    "log-symbols": "^4.0.0",
+    "node-fetch": "^2.6.0",
     "ora": "^4.0.5",
     "read": "^1.0.7"
   },

--- a/package.json
+++ b/package.json
@@ -24,9 +24,12 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "@octokit/rest": "^18.0.3",
     "application-config": "^2.0.0",
     "bl": "^4.0.0",
     "hyperquest": "^2.1.3",
+    "log-symbols": "^4.0.0",
+    "ora": "^4.0.5",
     "read": "^1.0.7"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR implements the oauth device flow, with a PAT fallback.  There are a few more edge cases I need to handle right now, as well as update the docs and make sure I didn't break the api contract too much. 

For better or for worse, I followed the existing design decisions of the existing module.  Still, this effectively rewrites the entire prompt flow, changes some options and generally will require an upgrade guide to help people figure out how to register an oauth app on github (to be written). 

So.. not quite done yet, but this is the direction its head in.  Early comments welcome. 

Closes https://github.com/rvagg/ghauth/issues/26

Definitely a breaking change.  Will require a few changes to options and the creation of a OAuth app on GitHub.  Already logged in sessions should still keep working though, and the new tokens will work exactly the same way as the old PAT tokens.