### PR TITLE
replace `node-fetch` with built-in `fetch`

### DIFF
--- a/ghauth.js
+++ b/ghauth.js
@@ -2,7 +2,6 @@
 
 const { promisify } = require('util')
 const read = promisify(require('read'))
-const fetch = require('node-fetch')
 const appCfg = require('application-config')
 const querystring = require('querystring')
 const ora = require('ora')

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "dependencies": {
     "application-config": "^2.0.0",
-    "node-fetch": "^2.6.0",
     "ora": "^4.0.5",
     "read": "^1.0.7"
   },


### PR DESCRIPTION
The current version relies pulls in `whatwg-url` package, which emits the following warning on Node.js 21.x: ``(node:27960) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.``

I think it would make sense to drop the dependency on `node-fetch` now that Node.js ships with a `fetch` implementation.

BREAKING CHANGE: Node.js 18+ is required