### PR TITLE
feat!: ESM-only with Node.js 20+, improved PAT flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 5
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -14,3 +16,5 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 5

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -1,60 +1,52 @@
 name: Test & Maybe Release
 on: [push, pull_request]
+
 jobs:
   test:
     strategy:
       fail-fast: false
       matrix:
-        node: [18.x, 20.x, lts/*]
+        node: [lts/*, current]
         os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node }}
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
       - name: Install Dependencies
-        run: |
-          npm install --no-progress
+        run: npm install --no-progress
       - name: Run tests
-        run: |
-          npm test
+        run: npm test
+
   release:
     name: Release
     needs: test
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Node.js
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6
         with:
           node-version: lts/*
+          registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies
-        run: |
-          npm install --no-progress --no-package-lock --no-save
+        run: npm install --no-progress --no-package-lock --no-save
       - name: Build
-        run: |
-          npm run build
-      - name: Install plugins
-        run: |
-          npm install \
-            @semantic-release/commit-analyzer \
-            conventional-changelog-conventionalcommits \
-            @semantic-release/release-notes-generator \
-            @semantic-release/npm \
-            @semantic-release/github \
-            @semantic-release/git \
-            @semantic-release/changelog \
-            --no-progress --no-package-lock --no-save
+        run: npm run build
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npx semantic-release
-

--- a/README.md
+++ b/README.md
@@ -2,122 +2,129 @@
 
 **Create and load persistent GitHub authentication tokens for command-line apps**
 
-[![NPM](https://nodei.co/npm/ghauth.svg)](https://nodei.co/npm/ghauth/)
-
-**Important**
-
-Github deprecated their basic username/password auth api and have [scheduled to sunset it November 13, 2020](https://developer.github.com/changes/2020-02-14-deprecating-oauth-auth-endpoint/).  `ghauth` v5.0.0+ supports the new [device auth flow](https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow) but requires some implementation changes and application registration with Github. Review the new API docs and see [Setup](#setup) for a simple upgrade guide between v4 and v5.
+[![NPM](https://nodei.co/npm/ghauth.svg?style=flat&data=n,v&color=blue)](https://nodei.co/npm/ghauth/)
 
 ## Example usage
 
 ```js
-const ghauth = require('ghauth')
-const authOptions = {
-  // provide a clientId from a Github oAuth application registration
-  clientId: '123456',
+import ghauth from 'ghauth'
 
-  // awesome.json within the user's config directory will store the token
-  configName: 'awesome',
+const authData = await ghauth({
+  configName: 'my-app',
+  scopes: ['repo']
+})
 
-  // (optional) whatever GitHub auth scopes you require
-  scopes: [ 'user' ],
-
-  // (optional)
-  userAgent: 'My Awesome App'
-}
-
-const authData = await ghauth(authOptions)
 console.log(authData)
-
-// can also be run with a callback as:
-//
-// ghauth(authOptions, function (err, authData) {
-//  console.log(authData)
-// })
-
+// { user: 'rvagg', token: 'ghp_...' }
 ```
 
-Will run something like this:
+On first run, this prompts the user to create a [Personal Access Token](https://github.com/settings/tokens). The token is saved to `~/.config/my-app/config.json` (Linux), `~/Library/Application Support/my-app/config.json` (macOS), or `%APPDATA%/my-app/config.json` (Windows). Subsequent runs return the cached token without prompting.
 
 ```console
-$ node awesome.js
-  Authorize with GitHub by opening this URL in a browser:
+$ node my-app.js
+Personal access token auth for Github.
 
-    https://github.com/login/device
+  Create a Personal Access Token at https://github.com/settings/tokens
 
-  and enter the following User Code:
-  (or press ⏎ to enter a personal access token)
+    1. Click "Generate new token" → "Generate new token (classic)"
+       (fine-grained tokens also work)
+    2. Set a name, e.g. "my-app"
+    3. Select scopes: repo
+    4. Generate and copy the token
 
-✔ Device flow complete.  Manage at https://github.com/settings/connections/applications/123456
+Paste your token here: ✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔✔
 ✔ Authorized for rvagg
-Wrote access token to "~/.config/awesome/config.json"
-{
-  token: '24d5dee258c64aef38a66c0c5eca459c379901c2',
-  user: 'rvagg'
-}
-```
-
-Because the token is persisted, the next time you run it there will be no prompts:
-
-```console
-$ node awesome.js
-
-{ user: 'rvagg',
-  token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
-```
-
-When `authUrl` is configured for a Github enterprise endpoint, it will look more like this:
-
-```console
-$ node awesome.js
-
-GitHub username: rvagg
-GitHub password: ✔✔✔✔✔✔✔✔✔✔✔✔
-GitHub OTP (optional): 669684
-
-{ user: 'rvagg',
-  token: '24d5dee258c64aef38a66c0c5eca459c379901c2' }
+Wrote access token to "/home/rvagg/.config/my-app/config.json"
+{ user: 'rvagg', token: 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' }
 ```
 
 ## API
 
-<b><code>ghauth(options, callback)</code></b>
+<b><code>ghauth(options)</code></b>
 
-The <b><code>options</code></b> argument can have the following properties:
+Returns a `Promise` that resolves to `{ user: String, token: String }`.
 
-* `clientId` (String, required unless `noDeviceFlow` is `true`): the clientId of your oAuth application on Github.  See [setup](#setup) below for more info on creating a Github oAuth application.
-* `configName` (String, required unless `noSave` is `true`): the name of the config you are creating, this is required for saving a `<configName>.json` file into the users config directory with the token created. Note that the **config directory is determined by [application-config](https://github.com/LinusU/node-application-config) and is OS-specific.**
-* `noSave` (Boolean, optional): if you don't want to persist the token to disk, set this to `true` but be aware that you will still be creating a saved token on GitHub that will need cleaning up if you are not persisting the token.
-* `authUrl` (String, optional):  defaults to `null` since public Github no longer supports basic auth.  Setting `authUrl` will allow you to perform basic authentication with a Github Enterprise instance.  This setting is ignored if the `host` of the url is `api.github.com` or `github.com`.
-* `promptName` (String, optional): defaults to `'GitHub Enterprise'`, change this if you are prompting for GHE credentials.  Not used for public GH authentication.
-* `scopes` (Array, optional): defaults to `[]`, consult the GitHub [scopes](https://developer.github.com/v3/oauth/#scopes) documentation to see what you may need for your application.
-* `note` (String, optional):  defaults to `'Node.js command-line app with ghauth'`, override if you want to save a custom note with the GitHub token (user-visible).  Only used with GHE basic authentication.
-* `userAgent` (String, optional): defaults to `'Magic Node.js application that does magic things with ghauth'`, only used for requests to GitHub, override if you have a good reason to do so.
-* `passwordReplaceChar` (String, optional): defaults to `'✔'`, the character echoed when the user inputs their password. Can be set to `''` to silence the output.
-* `noDeviceFlow` (Boolean, optional): disable the Device Flow authentication method.  This will prompt users for a personal access token immediately if no existing configuration is found.  Only applies when `authUrl` is not used.
+### Options
 
-The <b><code>callback</code></b> will be called with either an `Error` object describing what went wrong, or a `data` object as the second argument if the auth creation (or cache read) was successful. The shape of the second argument is `{ user:String, token:String }`.
+| Option | Type | Required | Description |
+|--------|------|----------|-------------|
+| `configName` | String | Yes* | Name for the config file. Creates `<configName>/config.json` in the user's config directory. *Not required if `noSave: true`. |
+| `scopes` | Array | No | GitHub API [scopes](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/scopes-for-oauth-apps) your app requires. Defaults to `[]`. |
+| `noSave` | Boolean | No | Don't persist the token to disk. |
+| `clientId` | String | No | OAuth app client ID. If provided, uses device flow instead of PAT prompt. |
+| `noDeviceFlow` | Boolean | No | Force PAT prompt even if `clientId` is provided. |
+| `userAgent` | String | No | Custom User-Agent for GitHub API requests. |
+| `passwordReplaceChar` | String | No | Character to echo when entering tokens. Defaults to `'✔'`. |
+| `authUrl` | String | No | GitHub Enterprise auth URL (for GHE only). |
+| `promptName` | String | No | Name shown in prompts for GHE. Defaults to `'GitHub Enterprise'`. |
+| `note` | String | No | Note for the token (GHE only). |
 
-## Setup
+### Token formats
 
-Github requires a `clientId` from a Github oAuth Application in order to complete oAuth device flow authentication.
+ghauth accepts all GitHub PAT formats:
+- **Classic PATs**: 40 hex characters or `ghp_` prefix
+- **Fine-grained PATs**: `github_pat_` prefix
 
-1. Register an "oAuth Application" with Github:
-  - [Personal Account oAuth apps page](https://github.com/settings/developers)
-  - `https://github.com/organizations/${org_name}/settings/applications`: Organization oAuth settings page.
-2. Provide an application name, homepage URL and callback URL.  You can make these two URLs the same, since your app will not be using a callback URL with the device flow.
-3. Go to your oAuth application's settings page and take note of the "Client ID" (this will get passed as `clientId` to `ghauth`).  You can ignore the "Client Secret" value.  It is not used.
+## OAuth Device Flow
 
-The `clientId` is registered by the developer of the tool or CLI, and is baked into the code of your program.  Users do not need to set this up, onyl the publisher of the app.
+If you register an [OAuth App](https://github.com/settings/developers) with GitHub, you can use the device flow instead of asking users to create PATs manually. This provides a smoother UX where users authorize in their browser.
 
-- [Device flow docs](https://docs.github.com/en/developers/apps/authorizing-oauth-apps#device-flow)
+```js
+const authData = await ghauth({
+  clientId: 'your-oauth-app-client-id',
+  configName: 'my-app',
+  scopes: ['repo']
+})
+```
 
-### v4 to v5 Upgrade guide
+To set up an OAuth App:
+1. Go to [GitHub Developer Settings](https://github.com/settings/developers)
+2. Create a new OAuth App
+3. Set any URL for the callback (it's not used by device flow)
+4. Enable "Device Authorization Flow" in the app settings
+5. Use the Client ID (not the secret) in your code
 
-- A `options.clientId` is required to use device flow.  Set up an oAuth application to get a `clientId`.
-- the `options.authUrl` now only applies to GitHub enterprise authentication which still only supports basic auth.  Only pass this if you intend for GitHub Enterpise authentication.
-- `options.note` is only used for GHE basic auth now.  Your oAuth application details serve the purpose of token note.
-- `options.noDeviceFlow` is available to skip the device flow if you are unable to create a `clientId` for some reason, and wish to skip to the personal access token input prompt immediately.
+See [GitHub's device flow documentation](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow) for details.
+
+## GitHub Enterprise
+
+For GitHub Enterprise instances that use basic auth:
+
+```js
+const authData = await ghauth({
+  configName: 'my-app',
+  authUrl: 'https://github.mycompany.com/api/v3/authorizations',
+  scopes: ['repo']
+})
+```
+
+## v6 to v7 Migration
+
+**Breaking Changes:**
+
+1. **ESM only** - Update imports:
+   ```javascript
+   // Before (v6)
+   const ghauth = require('ghauth')
+
+   // After (v7)
+   import ghauth from 'ghauth'
+   ```
+
+2. **Promise-only API** - Callbacks removed:
+   ```javascript
+   // Before (v6)
+   ghauth(options, (err, data) => { ... })
+
+   // After (v7)
+   const data = await ghauth(options)
+   ```
+
+3. **Node.js 20+** required
+
+4. **PAT flow is now the default** - No need for `noDeviceFlow: true` or `clientId`. Just provide `configName` and optional `scopes`.
+
+5. **PAT validation updated** - Now accepts fine-grained PATs (`github_pat_` prefix) in addition to classic PATs.
 
 ## Contributing
 
@@ -126,10 +133,6 @@ ghauth is an **OPEN Open Source Project**. This means that:
 > Individuals making significant and valuable contributions are given commit-access to the project to contribute as they see fit. This project is more like an open wiki than a standard guarded open source project.
 
 See the [CONTRIBUTING.md](https://github.com/rvagg/ghauth/blob/master/CONTRIBUTING.md) file for more details.
-
-### A note about tests
-
-... there are no proper tests yet unfortunately. If you would like to contribute some that would be very helpful! We need to mock the GitHub API to properly test the functionality. Otherwise, testing of this library is done by its use downstream.
 
 ### Contributors
 
@@ -142,8 +145,7 @@ ghauth is made possible by the excellent work of the following contributors:
 <tr><th align="left">Bret Comnes</th><td><a href="https://github.com/bcomnes">GitHub/bcomnes</a></td><td><a href="http://twitter.com/bcomnes">Twitter/@bcomnes</a></td></tr>
 </tbody></table>
 
-License &amp; copyright
------------------------
+## License
 
 Copyright (c) 2014 ghauth contributors (listed above).
 

--- a/example.js
+++ b/example.js
@@ -1,19 +1,8 @@
-const ghauth = require('./')
-const authOptions = {
-  // provide a clientId from a Github oAuth application registration
-  clientId: '123456',
+import ghauth from './ghauth.js'
 
-  // ~/.config/awesome.json will store the token
-  configName: 'awesome',
-
-  // (optional) whatever GitHub auth scopes you require
-  scopes: ['user'],
-
-  // (optional)
-  userAgent: 'My Awesome App'
-}
-
-ghauth(authOptions, function (err, authData) {
-  if (err) throw err
-  console.log(authData)
+const authData = await ghauth({
+  configName: 'ghauth-example',
+  scopes: ['repo']
 })
+
+console.log(authData)

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,34 @@
+import { readFile, writeFile, mkdir } from 'node:fs/promises'
+import { join, dirname } from 'node:path'
+import { homedir, platform } from 'node:os'
+
+function getConfigPath (name) {
+  const home = homedir()
+  switch (platform()) {
+    case 'darwin':
+      return join(home, 'Library', 'Application Support', name, 'config.json')
+    case 'win32':
+      return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), name, 'config.json')
+    default:
+      return join(process.env.XDG_CONFIG_HOME || join(home, '.config'), name, 'config.json')
+  }
+}
+
+export function createConfig (name) {
+  const filePath = getConfigPath(name)
+  return {
+    filePath,
+    async read () {
+      try {
+        return JSON.parse(await readFile(filePath, 'utf8'))
+      } catch (err) {
+        if (err.code === 'ENOENT') return null
+        throw err
+      }
+    },
+    async write (data) {
+      await mkdir(dirname(filePath), { recursive: true })
+      await writeFile(filePath, JSON.stringify(data, null, 2))
+    }
+  }
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,75 @@
+/**
+ * Split a string at roughly `len` characters, being careful of word boundaries.
+ * @param {number} len - The target line length
+ * @param {string} str - The string to wrap
+ * @returns {string} The wrapped string
+ */
+export function newlineify (len, str) {
+  let s = ''
+  let l = 0
+  const sa = str.split(' ')
+
+  while (sa.length) {
+    if (l + sa[0].length > len) {
+      s += '\n'
+      l = 0
+    } else {
+      s += ' '
+    }
+    s += sa[0]
+    l += sa[0].length
+    sa.splice(0, 1)
+  }
+
+  return s
+}
+
+/**
+ * Sleep for a given number of seconds.
+ * @param {number} s - Seconds to sleep
+ * @returns {Promise<void>}
+ */
+export function sleep (s) {
+  const ms = s * 1000
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Create a Basic auth header value.
+ * @param {string} user - Username
+ * @param {string} pass - Password
+ * @returns {string} The Basic auth header value
+ */
+export function basicAuthHeader (user, pass) {
+  return `Basic ${Buffer.from(`${user}:${pass}`).toString('base64')}`
+}
+
+/**
+ * Check if the auth URL is for a GitHub Enterprise instance.
+ * @param {string|null|undefined} authUrl - The auth URL
+ * @returns {boolean} True if enterprise, false otherwise
+ */
+export function isEnterprise (authUrl) {
+  if (!authUrl) return false
+  const parsedAuthUrl = new URL(authUrl)
+  if (parsedAuthUrl.host === 'github.com') return false
+  if (parsedAuthUrl.host === 'api.github.com') return false
+  return true
+}
+
+/**
+ * Validate a GitHub personal access token format.
+ * Supports classic PATs (40 hex chars or ghp_ prefix) and fine-grained PATs (github_pat_ prefix).
+ * @param {string} token - The token to validate
+ * @returns {boolean} True if valid format, false otherwise
+ */
+export function isValidPat (token) {
+  if (!token || typeof token !== 'string') return false
+  // Classic PAT (old format): 40 hex characters
+  if (/^[0-9a-f]{40}$/i.test(token)) return true
+  // Classic PAT (new format): ghp_ prefix + 36-251 alphanumeric chars
+  if (/^ghp_[A-Za-z0-9]{36,251}$/.test(token)) return true
+  // Fine-grained PAT: github_pat_ prefix, ~93 chars total
+  if (/^github_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{59}$/.test(token)) return true
+  return false
+}

--- a/package.json
+++ b/package.json
@@ -2,10 +2,16 @@
   "name": "ghauth",
   "version": "6.0.19",
   "description": "Create and load persistent GitHub authentication tokens for command-line apps",
-  "main": "ghauth.js",
+  "type": "module",
+  "exports": "./ghauth.js",
+  "engines": {
+    "node": ">=20"
+  },
   "scripts": {
-    "lint": "standard *.js",
-    "test": "npm run lint && echo 'no tests to run'",
+    "lint": "standard",
+    "test:unit": "node --test test/*.test.js",
+    "test": "npm run lint && npm run test:unit",
+    "smoke": "node test/smoke.js",
     "build": "true"
   },
   "repository": {
@@ -25,12 +31,19 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "application-config": "^2.0.0",
-    "ora": "^4.0.5",
-    "read": "^1.0.7"
+    "ora": "^9.1.0",
+    "read": "^5.0.1"
   },
   "devDependencies": {
-    "standard": "^17.1.0"
+    "@semantic-release/changelog": "^6.0.3",
+    "@semantic-release/commit-analyzer": "^13.0.0",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^12.0.0",
+    "@semantic-release/npm": "^13.0.0",
+    "@semantic-release/release-notes-generator": "^14.0.1",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
+    "semantic-release": "^25.0.0",
+    "standard": "^17.1.2"
   },
   "release": {
     "branches": [

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -1,0 +1,98 @@
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+describe('config', () => {
+  let tempDir
+  let originalXdgConfigHome
+  let originalAppdata
+  let originalHome
+
+  before(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'ghauth-test-'))
+    originalXdgConfigHome = process.env.XDG_CONFIG_HOME
+    originalAppdata = process.env.APPDATA
+    originalHome = process.env.HOME
+    process.env.XDG_CONFIG_HOME = tempDir
+  })
+
+  after(async () => {
+    if (originalXdgConfigHome !== undefined) {
+      process.env.XDG_CONFIG_HOME = originalXdgConfigHome
+    } else {
+      delete process.env.XDG_CONFIG_HOME
+    }
+    if (originalAppdata !== undefined) {
+      process.env.APPDATA = originalAppdata
+    }
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome
+    }
+    await rm(tempDir, { recursive: true, force: true })
+  })
+
+  it('read returns null for missing config', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const config = createConfig('nonexistent-test-app')
+    const data = await config.read()
+    assert.equal(data, null)
+  })
+
+  it('write creates config file and read retrieves it', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const config = createConfig('test-write-read')
+    const testData = { user: 'testuser', token: 'testtoken123' }
+
+    await config.write(testData)
+    const readData = await config.read()
+
+    assert.deepEqual(readData, testData)
+  })
+
+  it('write creates nested directories', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const config = createConfig('nested-test-app')
+    const testData = { foo: 'bar' }
+
+    await config.write(testData)
+
+    const fileContent = await readFile(config.filePath, 'utf8')
+    assert.deepEqual(JSON.parse(fileContent), testData)
+  })
+
+  it('write overwrites existing config', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const config = createConfig('overwrite-test')
+
+    await config.write({ old: 'data' })
+    await config.write({ new: 'data' })
+
+    const readData = await config.read()
+    assert.deepEqual(readData, { new: 'data' })
+  })
+
+  it('filePath is set correctly', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const config = createConfig('filepath-test')
+
+    assert.ok(config.filePath.includes('filepath-test'))
+    assert.ok(config.filePath.endsWith('config.json'))
+  })
+
+  it('handles JSON parsing errors gracefully', async () => {
+    const { createConfig } = await import('../lib/config.js')
+    const { writeFile, mkdir } = await import('node:fs/promises')
+    const { dirname } = await import('node:path')
+
+    const config = createConfig('invalid-json-test')
+    await mkdir(dirname(config.filePath), { recursive: true })
+    await writeFile(config.filePath, 'not valid json{{{', 'utf8')
+
+    await assert.rejects(
+      () => config.read(),
+      SyntaxError
+    )
+  })
+})

--- a/test/ghauth.test.js
+++ b/test/ghauth.test.js
@@ -1,0 +1,227 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import ghauth from '../ghauth.js'
+
+function createMockDeps (overrides = {}) {
+  return {
+    createConfig: (name) => ({
+      filePath: `/fake/path/${name}/config.json`,
+      read: async () => null,
+      write: async () => {}
+    }),
+    ora: () => ({
+      start: function () { return this },
+      succeed: function () { return this },
+      fail: function () { return this },
+      warn: function () { return this },
+      text: function () { return this }
+    }),
+    read: async () => '',
+    fetch: async () => ({
+      json: async () => ({}),
+      headers: { get: () => null },
+      arrayBuffer: async () => ({})
+    }),
+    ...overrides
+  }
+}
+
+describe('ghauth', () => {
+  it('throws if options is not an object', async () => {
+    await assert.rejects(
+      () => ghauth(null, createMockDeps()),
+      {
+        name: 'TypeError',
+        message: 'ghauth requires an options argument'
+      }
+    )
+  })
+
+  it('throws if options is a string', async () => {
+    await assert.rejects(
+      () => ghauth('invalid', createMockDeps()),
+      {
+        name: 'TypeError',
+        message: 'ghauth requires an options argument'
+      }
+    )
+  })
+
+  it('throws if configName is missing when noSave is false', async () => {
+    await assert.rejects(
+      () => ghauth({ clientId: 'test' }, createMockDeps()),
+      {
+        name: 'TypeError',
+        message: 'ghauth requires an options.configName property'
+      }
+    )
+  })
+
+  it('defaults to PAT flow when clientId is not provided', async () => {
+    let patFlowUsed = false
+    const mockDeps = createMockDeps({
+      read: async (opts) => {
+        if (opts.prompt.includes('token')) {
+          patFlowUsed = true
+          return 'a'.repeat(40)
+        }
+        return ''
+      },
+      fetch: async () => ({
+        json: async () => ({ login: 'testuser' }),
+        headers: { get: () => null },
+        arrayBuffer: async () => ({})
+      })
+    })
+
+    await ghauth({ configName: 'test' }, mockDeps)
+    assert.equal(patFlowUsed, true, 'should use PAT flow when clientId is missing')
+  })
+
+  it('returns cached token if available', async () => {
+    const cachedData = { user: 'cacheduser', token: 'cachedtoken123' }
+    const mockDeps = createMockDeps({
+      createConfig: () => ({
+        filePath: '/fake/path/config.json',
+        read: async () => cachedData,
+        write: async () => {}
+      })
+    })
+
+    const result = await ghauth({ configName: 'test', clientId: 'x' }, mockDeps)
+    assert.deepEqual(result, cachedData)
+  })
+
+  it('returns cached token even without clientId if token exists', async () => {
+    const cachedData = { user: 'existinguser', token: 'existingtoken' }
+    const mockDeps = createMockDeps({
+      createConfig: () => ({
+        filePath: '/fake/path/config.json',
+        read: async () => cachedData,
+        write: async () => {}
+      })
+    })
+
+    const result = await ghauth({ configName: 'test' }, mockDeps)
+    assert.deepEqual(result, cachedData)
+  })
+
+  it('does not require configName when noSave is true', async () => {
+    const mockDeps = createMockDeps({
+      createConfig: () => {
+        throw new Error('createConfig should not be called')
+      }
+    })
+
+    await assert.rejects(
+      () => ghauth({ noSave: true, clientId: 'test', noDeviceFlow: true }, mockDeps),
+      { name: 'TypeError' }
+    )
+  })
+
+  it('skips config read when noSave is true', async () => {
+    let configReadCalled = false
+    const mockDeps = createMockDeps({
+      createConfig: () => ({
+        filePath: '/fake/path/config.json',
+        read: async () => {
+          configReadCalled = true
+          return { user: 'test', token: 'test' }
+        },
+        write: async () => {}
+      }),
+      read: async () => 'a'.repeat(40),
+      fetch: async () => ({
+        json: async () => ({ login: 'testuser' }),
+        headers: { get: () => null },
+        arrayBuffer: async () => ({})
+      })
+    })
+
+    await ghauth({ noSave: true, clientId: 'test', noDeviceFlow: true }, mockDeps)
+    assert.equal(configReadCalled, false, 'config.read should not be called when noSave is true')
+  })
+
+  describe('noDeviceFlow mode', () => {
+    it('prompts for PAT when noDeviceFlow is true', async () => {
+      let readPromptCalled = false
+      const mockDeps = createMockDeps({
+        read: async (opts) => {
+          readPromptCalled = true
+          if (opts.prompt.includes('token')) {
+            return 'a'.repeat(40)
+          }
+          return ''
+        },
+        fetch: async () => ({
+          json: async () => ({ login: 'testuser' }),
+          headers: { get: () => null },
+          arrayBuffer: async () => ({})
+        })
+      })
+
+      const result = await ghauth({
+        configName: 'test',
+        noDeviceFlow: true
+      }, mockDeps)
+
+      assert.equal(readPromptCalled, true)
+      assert.equal(result.token, 'a'.repeat(40))
+    })
+
+    it('throws on empty PAT', async () => {
+      const mockDeps = createMockDeps({
+        read: async () => ''
+      })
+
+      await assert.rejects(
+        () => ghauth({ configName: 'test', noDeviceFlow: true }, mockDeps),
+        {
+          name: 'TypeError',
+          message: 'Empty personal access token received.'
+        }
+      )
+    })
+
+    it('throws on invalid PAT format', async () => {
+      const mockDeps = createMockDeps({
+        read: async () => 'invalid-token-format'
+      })
+
+      await assert.rejects(
+        () => ghauth({ configName: 'test', noDeviceFlow: true }, mockDeps),
+        {
+          name: 'TypeError',
+          message: 'Invalid personal access token format'
+        }
+      )
+    })
+  })
+
+  describe('enterprise mode', () => {
+    it('uses enterprise prompt for enterprise URLs', async () => {
+      let usernamePromptSeen = false
+      const mockDeps = createMockDeps({
+        read: async (opts) => {
+          if (opts.prompt.includes('username')) {
+            usernamePromptSeen = true
+            return ''
+          }
+          return ''
+        }
+      })
+
+      await assert.rejects(
+        () => ghauth({
+          configName: 'test',
+          authUrl: 'https://enterprise.example.com/api/v3/authorizations'
+        }, mockDeps),
+        {
+          message: 'Authentication error: token or user not generated'
+        }
+      )
+
+      assert.equal(usernamePromptSeen, true)
+    })
+  })
+})

--- a/test/smoke.js
+++ b/test/smoke.js
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+
+/**
+ * Smoke test for ghauth ESM migration.
+ * Run with: node test/smoke.js
+ *
+ * This test prompts you for a PAT to verify the full auth flow works.
+ */
+
+import ghauth from '../ghauth.js'
+
+console.log('ghauth ESM smoke test\n')
+
+try {
+  const authData = await ghauth({
+    configName: 'ghauth-smoke-test',
+    scopes: ['read:user'],
+    noSave: true
+  })
+
+  console.log('\nSmoke test PASSED!')
+  console.log('Authenticated as:', authData.user)
+} catch (err) {
+  console.error('\nSmoke test FAILED:', err.message)
+  process.exit(1)
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,132 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { newlineify, sleep, basicAuthHeader, isEnterprise, isValidPat } from '../lib/utils.js'
+
+describe('newlineify', () => {
+  it('wraps text at specified length', () => {
+    const result = newlineify(20, 'hello world this is a test')
+    assert.ok(result.includes('\n'))
+    const lines = result.split('\n')
+    for (const line of lines) {
+      assert.ok(line.length <= 25, `line "${line}" exceeds limit`)
+    }
+  })
+
+  it('handles empty string', () => {
+    const result = newlineify(80, '')
+    assert.equal(result, ' ')
+  })
+
+  it('handles single word', () => {
+    const result = newlineify(80, 'hello')
+    assert.equal(result.trim(), 'hello')
+  })
+
+  it('preserves words without breaking them', () => {
+    const result = newlineify(5, 'hello world test')
+    assert.ok(result.includes('hello'))
+    assert.ok(result.includes('world'))
+    assert.ok(result.includes('test'))
+  })
+})
+
+describe('sleep', () => {
+  it('returns a promise', () => {
+    const result = sleep(0)
+    assert.ok(result instanceof Promise)
+  })
+
+  it('resolves after the specified time', async () => {
+    const start = Date.now()
+    await sleep(0.05)
+    const elapsed = Date.now() - start
+    assert.ok(elapsed >= 40, `elapsed time ${elapsed}ms should be at least 40ms`)
+  })
+})
+
+describe('basicAuthHeader', () => {
+  it('creates valid base64 header', () => {
+    const result = basicAuthHeader('user', 'pass')
+    assert.equal(result, 'Basic dXNlcjpwYXNz')
+  })
+
+  it('handles special characters', () => {
+    const result = basicAuthHeader('user@example.com', 'p@ss:word!')
+    const decoded = Buffer.from(result.replace('Basic ', ''), 'base64').toString()
+    assert.equal(decoded, 'user@example.com:p@ss:word!')
+  })
+
+  it('handles empty password', () => {
+    const result = basicAuthHeader('user', '')
+    const decoded = Buffer.from(result.replace('Basic ', ''), 'base64').toString()
+    assert.equal(decoded, 'user:')
+  })
+})
+
+describe('isEnterprise', () => {
+  it('returns false for null', () => {
+    assert.equal(isEnterprise(null), false)
+  })
+
+  it('returns false for undefined', () => {
+    assert.equal(isEnterprise(undefined), false)
+  })
+
+  it('returns false for github.com URLs', () => {
+    assert.equal(isEnterprise('https://github.com/login'), false)
+  })
+
+  it('returns false for api.github.com URLs', () => {
+    assert.equal(isEnterprise('https://api.github.com/authorizations'), false)
+  })
+
+  it('returns true for enterprise URLs', () => {
+    assert.equal(isEnterprise('https://github.mycompany.com/api/v3'), true)
+  })
+
+  it('returns true for custom domain enterprise URLs', () => {
+    assert.equal(isEnterprise('https://enterprise.example.org/api/v3/authorizations'), true)
+  })
+})
+
+describe('isValidPat', () => {
+  it('returns false for null', () => {
+    assert.equal(isValidPat(null), false)
+  })
+
+  it('returns false for undefined', () => {
+    assert.equal(isValidPat(undefined), false)
+  })
+
+  it('returns false for empty string', () => {
+    assert.equal(isValidPat(''), false)
+  })
+
+  it('returns false for invalid format', () => {
+    assert.equal(isValidPat('invalid-token'), false)
+    assert.equal(isValidPat('tooshort'), false)
+  })
+
+  it('accepts classic PAT (40 hex chars)', () => {
+    assert.equal(isValidPat('a'.repeat(40)), true)
+    assert.equal(isValidPat('1234567890abcdef1234567890abcdef12345678'), true)
+  })
+
+  it('accepts classic PAT with ghp_ prefix', () => {
+    assert.equal(isValidPat('ghp_' + 'a'.repeat(36)), true)
+    assert.equal(isValidPat('ghp_' + 'A1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p6Q7r8'), true)
+  })
+
+  it('accepts fine-grained PAT with github_pat_ prefix', () => {
+    const fineGrained = 'github_pat_' + 'a'.repeat(22) + '_' + 'b'.repeat(59)
+    assert.equal(isValidPat(fineGrained), true)
+  })
+
+  it('rejects ghp_ with wrong length', () => {
+    assert.equal(isValidPat('ghp_tooshort'), false)
+  })
+
+  it('rejects github_pat_ with wrong format', () => {
+    assert.equal(isValidPat('github_pat_tooshort'), false)
+  })
+})


### PR DESCRIPTION
BREAKING CHANGE: ESM only, promise-only API, requires Node.js >=20

- Replace application-config with native modules
- Support fine-grained PATs (github_pat_ prefix)
- Add step-by-step PAT creation prompts
- Add test suite (42 tests)
- Update deps: ora@9, read@5